### PR TITLE
Remove CP and DP segmentation differences and update documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,18 +100,21 @@ Doing so will cause issues with multiple instances of CellPose trying to utilize
 ### Necessary Packages:
 
 The necessary packages for idrstream **using DeepProfiler** can be installed into a conda environment with the following:
+
 ```console
 # Run this command to create the conda environment for idrstream
 conda env create -f idrstream_dp_env.yml
 ```
 
 The necessary packages for idrstream **using CellProfiler** can be installed into a conda environment with the following:
+
 ```console
 # Run this command to create the conda environment for idrstream
 conda env create -f idrstream_cp_env.yml
 ```
 
 This environment must be activated before using `idrstream` with the following:
+
 ```console
 # Run this command to activate the conda environment for idrstream with Cellprofiler
 conda activate idrstream_cp
@@ -227,6 +230,7 @@ Close the GUI and reopen to confirm the path is correct.
 DeepProfiler must be installed via Github.
 Commit [`2fb3ed3`](https://github.com/cytomining/DeepProfiler/commit/2fb3ed3027cded6676b7e409687322ef67491ec7) was used while developing `idrstream`.
 Install the repository into `idrstream/` with:
+
 ```console
 # make sure that the conda environment `idrstream_dp` is activated
 conda activate idrstream_dp
@@ -237,6 +241,7 @@ pip install -e .
 ```
 
 Installing this version of DeepProfiler will downgrade numpy to the wrong version, so it is necessary to reinstall numpy with:
+
 ```console
 # make sure that the conda environment `idrstream_dp` is activated
 conda activate idrstream_dp

--- a/README.md
+++ b/README.md
@@ -125,6 +125,14 @@ conda activate idrstream_dp
 
 Install Aspera high-speed transfer client as described at https://github.com/IBM/aspera-cli#installation.
 We used the direct installation method.
+On Ubuntu, the direct installation method is as follows:
+
+1) Install Ruby on Ubuntu: `sudo apt install ruby-full`
+2) Confirm Ruby install: `ruby --version`
+3) Install aspera-cli gem: `gem install aspera-cli`
+4) Upgrade aspera-cli gem to latest version: `gem update aspera-cli`
+5) Install acsp: `ascli conf ascp install`
+6) Confirm install and locate acsp (for step 1a): `ascli config ascp show`
 
 ##### Step 1a: Allow Aspera to run without password
 
@@ -216,15 +224,23 @@ Close the GUI and reopen to confirm the path is correct.
 
 # DeepProfiler Project Setup:
 
-Deep Profiler must be installed via Github.
+DeepProfiler must be installed via Github.
 Commit [`2fb3ed3`](https://github.com/cytomining/DeepProfiler/commit/2fb3ed3027cded6676b7e409687322ef67491ec7) was used while developing `idrstream`.
 Install the repository into `idrstream/` with:
 ```sh
+# make sure that the conda environment `idrstream_dp` is activated
+conda activate idrstream_dp
 cd idrstream/
 git clone https://github.com/cytomining/DeepProfiler.git
 cd DeepProfiler/
-# make sure that the conda environment `idrstream_dp` is activated
 pip install -e .
+```
+
+Installing this version of DeepProfiler will downgrade numpy to the wrong version, so it is necessary to reinstall numpy with:
+```sh
+# make sure that the conda environment `idrstream_dp` is activated
+conda activate idrstream_dp
+pip install numpy==1.23.3
 ```
 
 ## Example Usage

--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ conda activate idrstream_dp
 
 #### Step 1: Install Aspera
 
-Install Aspera high-speed transfer client as described at https://github.com/IBM/aspera-cli#installation.
+Install Aspera high-speed transfer client as described at <https://github.com/IBM/aspera-cli#installation>.
 We used the direct installation method.
 On Ubuntu, the direct installation method is as follows:
 

--- a/README.md
+++ b/README.md
@@ -100,19 +100,19 @@ Doing so will cause issues with multiple instances of CellPose trying to utilize
 ### Necessary Packages:
 
 The necessary packages for idrstream **using DeepProfiler** can be installed into a conda environment with the following:
-```sh
+```console
 # Run this command to create the conda environment for idrstream
 conda env create -f idrstream_dp_env.yml
 ```
 
 The necessary packages for idrstream **using CellProfiler** can be installed into a conda environment with the following:
-```sh
+```console
 # Run this command to create the conda environment for idrstream
 conda env create -f idrstream_cp_env.yml
 ```
 
 This environment must be activated before using `idrstream` with the following:
-```sh
+```console
 # Run this command to activate the conda environment for idrstream with Cellprofiler
 conda activate idrstream_cp
 # Run this command to activate the conda environment for idrstream with Deepprofiler
@@ -161,7 +161,7 @@ PyBaisc is currently under development and cannot be installed with `pip`.
 This is overcome by using a locally-downloaded version of PyBasic.
 Clone the repository into `idrstream/` with:
 
-```sh
+```console
 cd idrstream/
 git clone https://github.com/peng-lab/PyBaSiC.git
 cd PyBaSiC/
@@ -227,7 +227,7 @@ Close the GUI and reopen to confirm the path is correct.
 DeepProfiler must be installed via Github.
 Commit [`2fb3ed3`](https://github.com/cytomining/DeepProfiler/commit/2fb3ed3027cded6676b7e409687322ef67491ec7) was used while developing `idrstream`.
 Install the repository into `idrstream/` with:
-```sh
+```console
 # make sure that the conda environment `idrstream_dp` is activated
 conda activate idrstream_dp
 cd idrstream/
@@ -237,7 +237,7 @@ pip install -e .
 ```
 
 Installing this version of DeepProfiler will downgrade numpy to the wrong version, so it is necessary to reinstall numpy with:
-```sh
+```console
 # make sure that the conda environment `idrstream_dp` is activated
 conda activate idrstream_dp
 pip install numpy==1.23.3

--- a/README.md
+++ b/README.md
@@ -156,6 +156,8 @@ Clone the repository into `idrstream/` with:
 ```sh
 cd idrstream/
 git clone https://github.com/peng-lab/PyBaSiC.git
+cd PyBaSiC/
+git checkout f3fcf1987db47c4a29506d240d0f69f117c82d2b
 ```
 
 **Note:** The version of PyBaSic we use needs at least 3 images to perform illumination correction.

--- a/idrstream/segment.py
+++ b/idrstream/segment.py
@@ -69,17 +69,19 @@ class CellPoseSegmentor:
             dataframe with object center coords
         """
         objects_data = []
-
-        cellpose_model = models.Cellpose(
+        
+        cellpose_model = models.CellposeModel(
             gpu=self.use_GPU, model_type=self.model_specs["model_type"]
         )
-        masks, flows, styles, diams = cellpose_model.eval(
+        
+        masks, flows, *_ = cellpose_model.eval(
             image,
             diameter=self.model_specs["diameter"],
             channels=self.model_specs["channels"],
             flow_threshold=self.model_specs["flow_threshold"],
             cellprob_threshold=self.model_specs["cellprob_threshold"],
         )
+        
         # remove cell masks if they are on the edge
         if self.model_specs["remove_edge_masks"]:
             masks = utils.remove_edge_masks(masks)

--- a/idrstream_cp_env.yml
+++ b/idrstream_cp_env.yml
@@ -24,6 +24,6 @@ dependencies:
 - conda-forge::sentry-sdk=0.18.0
 - pip:
   - cellprofiler==4.2.4
-  - cellpose==2.1.0
   - cellpose[gui]
   - git+https://github.com/cytomining/pycytominer
+  - cellpose==2.1.0

--- a/idrstream_dp_env.yml
+++ b/idrstream_dp_env.yml
@@ -6,10 +6,10 @@ dependencies:
   - conda-forge::jupyter=1.0.0
   - conda-forge::pandas=1.4.2
   - conda-forge::pytorch=1.11.0
-  - conda-forge::cellpose=2.0.5
   - conda-forge::scikit-image=0.19.3
   - conda-forge::pyimagej=1.2.1
   - conda-forge::pip=22.1.2
   - conda-forge::numpy=1.23.3
   - pip:
     - git+https://github.com/cytomining/pycytominer
+    - cellpose==2.1.0


### PR DESCRIPTION
This PR is ready for review and addresses 3 [issues](https://github.com/WayScience/IDR_stream/issues) with very small changes.

#9 - CP/DP Segmentation Differences: 
These segmentation differences were caused by using different versions of CellPose and instantiating CellPose with `models.Cellpose` instead of `models.CellposeModel`

#10 - DP Environment Installation Issues:
After installing DP, numpy needs to be upgraded with `pip install numpy==1.23.3`

#11 - Aspera Installation Instructions:
The installation instructions for Aspera have been updated to make it easier for Ubuntu users to follow along.