### PR TITLE
Fix cp dp diffs 2

### DIFF
--- a/idrstream/CP_Plugins/runcellpose.py
+++ b/idrstream/CP_Plugins/runcellpose.py
@@ -409,6 +409,8 @@ The default is set to "Yes".
             channels = [0, 0]
 
         diam = self.expected_diameter.value if self.expected_diameter.value > 0 else None
+        
+        x_data = (x_data * 255).round().astype(numpy.uint8)
 
         try:
             if float(cellpose_ver[0:3]) >= 0.7 and int(cellpose_ver[0])<2:

--- a/idrstream/CP_Plugins/runcellpose.py
+++ b/idrstream/CP_Plugins/runcellpose.py
@@ -410,7 +410,8 @@ The default is set to "Yes".
 
         diam = self.expected_diameter.value if self.expected_diameter.value > 0 else None
         
-        # convert float image data to int image data to remove segmentation differences between the image types
+        # convert float image data to int image data to remove segmentation differences between CP and DP runs
+        # (DP uses int image data)
         x_data = (x_data * 255).round().astype(numpy.uint8)
 
         try:

--- a/idrstream/CP_Plugins/runcellpose.py
+++ b/idrstream/CP_Plugins/runcellpose.py
@@ -410,6 +410,7 @@ The default is set to "Yes".
 
         diam = self.expected_diameter.value if self.expected_diameter.value > 0 else None
         
+        # convert float image data to int image data to remove segmentation differences between the image types
         x_data = (x_data * 255).round().astype(numpy.uint8)
 
         try:


### PR DESCRIPTION
This PR is ready for review!

This PR converts CellProfiler-loaded images from float (how CP loads them) to int (how DP loads them and their original data format). It turns out that float image data and int image data result in different CellPose segmentations for the same image. This difference, with examples, is explained more at the bottom of https://github.com/WayScience/IDR_stream/issues/17.